### PR TITLE
S3 support and a new option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,27 @@ The image will be tagged with the value of `version` from _Chart.yaml_.
   ]
 }
 ```
+
+## S3 Example
+
+In order to use s3 as a helm repo, you need to use the [helm-s3](https://github.com/hypnoglow/helm-s3) plugin.
+Before you run semantic release, you need to add your s3 bucket to your repos: `helm repo add my-s3-bucket-repo s3://my-s3-bucket/charts`.
+
+This will update versions in `./chart/Chart.yaml`
+and push the chart to `my-s3-bucket`.
+The image will be tagged with the value of `version` from _Chart.yaml_.
+
+```
+{
+  "plugins": [
+    [
+      "semantic-release-helm",
+      {
+        path: './chart',
+        registry: 'my-s3-bucket-repo',
+        useS3: true,
+      }
+    ]
+  ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -36,11 +36,18 @@ New chart version is 1.0.0
 
 ## Configuration
 
-- path (required)  
+- path (required) - string
 Chart directory, where the _Chart.yaml_ is located.
 
-- registry (optional)  
+- registry (optional) - string
 URI of a container registry.
+
+- useS3 (optional) - boolean
+Use S3 instead of a HTTP repo (see example for more details)
+
+- onlyUpdateVersion (optional) - boolean
+Only update the `version` and NOT the `appVersion`. This is useful if you have the chart in a different git repo than the application.
+**IMPORTANT:** `version` will be set to `nextRelease.version`!
 
 Pass credentials through environment variables accordingly:
 

--- a/README.md
+++ b/README.md
@@ -41,19 +41,24 @@ Chart directory, where the _Chart.yaml_ is located.
 
 - registry (optional) - string
 URI of a container registry.
-
-- useS3 (optional) - boolean
-Use S3 instead of a HTTP repo (see example for more details)
+Use `s3://` if you want to push to a s3 bucket
 
 - onlyUpdateVersion (optional) - boolean
 Only update the `version` and NOT the `appVersion`. This is useful if you have the chart in a different git repo than the application.
-**IMPORTANT:** `version` will be set to `nextRelease.version`!
 
 Pass credentials through environment variables accordingly:
 
 ```
 export REGISTRY_USERNAME=<USERNAME>
 export REGISTRY_PASSWORD=<PASSWORD>
+```
+
+If you want to use s3, use the folling environment variables for your AWS credentials:
+
+```
+export AWS_REGION=<REGION> (e.g. eu-central-1)
+export AWS_ACCESS_KEY_ID=<KEY_ID>
+export AWS_SECRET_ACCESS_KEY=<SECRET>
 ```
 
 ## Example
@@ -78,11 +83,10 @@ The image will be tagged with the value of `version` from _Chart.yaml_.
 
 ## S3 Example
 
-In order to use s3 as a helm repo, you need to use the [helm-s3](https://github.com/hypnoglow/helm-s3) plugin.
-Before you run semantic release, you need to add your s3 bucket to your repos: `helm repo add my-s3-bucket-repo s3://my-s3-bucket/charts`.
+semantic-release-helm uses the [helm-s3](https://github.com/hypnoglow/helm-s3) plugin in the background. If you want to use a thrid party s3 repo, you can take a look at the documentation of the plugin.
 
 This will update versions in `./chart/Chart.yaml`
-and push the chart to `my-s3-bucket`.
+and push the chart to `s3://my-s3-bucket/s3-prefix`.
 The image will be tagged with the value of `version` from _Chart.yaml_.
 
 ```
@@ -92,8 +96,7 @@ The image will be tagged with the value of `version` from _Chart.yaml_.
       "semantic-release-helm",
       {
         path: './chart',
-        registry: 'my-s3-bucket-repo',
-        useS3: true,
+        registry: 's3://my-s3-bucket-repo/s3-prefix',
       }
     ]
   ]

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -14,8 +14,6 @@ module.exports = async (pluginConfig, context) => {
     const chartYaml = await fsPromises.readFile(filePath);
     const oldChart = yaml.safeLoad(chartYaml);
 
-    version = semver.inc(oldChart.version, context.nextRelease.type);
-
     if (pluginConfig.onlyUpdateVersion) {
         version = appVersion;
 
@@ -25,6 +23,8 @@ module.exports = async (pluginConfig, context) => {
         logger.log('Chart.yaml updated with version %s.', version);
         return;
     }
+
+    version = semver.inc(oldChart.version, context.nextRelease.type);
 
     const newChart = yaml.safeDump({...oldChart, version: version, appVersion: appVersion});
     await fsPromises.writeFile(filePath, newChart);

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -14,17 +14,15 @@ module.exports = async (pluginConfig, context) => {
     const chartYaml = await fsPromises.readFile(filePath);
     const oldChart = yaml.safeLoad(chartYaml);
 
-    if (pluginConfig.onlyUpdateVersion) {
-        version = appVersion;
+    version = semver.inc(oldChart.version, context.nextRelease.type);
 
+    if (pluginConfig.onlyUpdateVersion) {
         const newChart = yaml.safeDump({...oldChart, version: version});
         await fsPromises.writeFile(filePath, newChart);
 
         logger.log('Chart.yaml updated with version %s.', version);
         return;
     }
-
-    version = semver.inc(oldChart.version, context.nextRelease.type);
 
     const newChart = yaml.safeDump({...oldChart, version: version, appVersion: appVersion});
     await fsPromises.writeFile(filePath, newChart);

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -16,6 +16,16 @@ module.exports = async (pluginConfig, context) => {
 
     version = semver.inc(oldChart.version, context.nextRelease.type);
 
+    if (pluginConfig.onlyUpdateVersion) {
+        version = appVersion;
+
+        const newChart = yaml.safeDump({...oldChart, version: version});
+        await fsPromises.writeFile(filePath, newChart);
+
+        logger.log('Chart.yaml updated with version %s.', version);
+        return;
+    }
+
     const newChart = yaml.safeDump({...oldChart, version: version, appVersion: appVersion});
     await fsPromises.writeFile(filePath, newChart);
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -26,7 +26,7 @@ async function publishChart(configPath, registry, name, version) {
         ['dependency', 'update', configPath]
     );
 
-    if (pluginConfig.registry && pluginConfig.registry.startsWith('s3://')) {
+    if (registry && registry.startsWith('s3://')) {
         await execa(
             'helm',
             ['package', configPath]

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -12,7 +12,7 @@ module.exports = async (pluginConfig, context) => {
         const chartYaml = await fsPromises.readFile(filePath);
         const chart = yaml.safeLoad(chartYaml);
 
-        await publishChart(pluginConfig.path, pluginConfig.registry, chart.version);
+        await publishChart(pluginConfig.path, pluginConfig.registry, chart.name, chart.version, pluginConfig.useS3);
 
         logger.log('Chart successfully published.');
     } else {
@@ -20,10 +20,26 @@ module.exports = async (pluginConfig, context) => {
     }
 };
 
-async function publishChart(path, registry, version) {
+async function publishChart(configPath, registry, name, version, useS3 = false) {
+    if (useS3) {
+        await execa(
+            'helm',
+            ['package', configPath]
+        );
+        await execa(
+            'helm',
+            ['s3', 'push', path.join(configPath, `${name}-${version}.tgz`), registry]
+        );
+        await execa(
+            'rm',
+            [path.join(configPath, `${name}-${version}.tgz`)]
+        );
+        return;
+    }
+
     await execa(
         'helm',
-        ['chart', 'save', path, registry + ':' + version],
+        ['chart', 'save', configPath, registry + ':' + version],
         {
             env: {
                 HELM_EXPERIMENTAL_OCI: 1

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -12,7 +12,7 @@ module.exports = async (pluginConfig, context) => {
         const chartYaml = await fsPromises.readFile(filePath);
         const chart = yaml.safeLoad(chartYaml);
 
-        await publishChart(pluginConfig.path, pluginConfig.registry, chart.name, chart.version, pluginConfig.useS3);
+        await publishChart(pluginConfig.path, pluginConfig.registry, chart.name, chart.version);
 
         logger.log('Chart successfully published.');
     } else {
@@ -20,24 +20,28 @@ module.exports = async (pluginConfig, context) => {
     }
 };
 
-async function publishChart(configPath, registry, name, version, useS3 = false) {
+async function publishChart(configPath, registry, name, version) {
     await execa(
         'helm',
         ['dependency', 'update', configPath]
     );
 
-    if (useS3) {
+    if (pluginConfig.registry && pluginConfig.registry.startsWith('s3://')) {
         await execa(
             'helm',
             ['package', configPath]
         );
         await execa(
             'helm',
-            ['s3', 'push', path.join(configPath, `${name}-${version}.tgz`), registry]
+            ['s3', 'push', path.join(configPath, `${name}-${version}.tgz`), 'semantic-release-helm-repo']
         );
         await execa(
             'rm',
             [path.join(configPath, `${name}-${version}.tgz`)]
+        );
+        await execa(
+            'helm',
+            ['repo', 'rm', 'semantic-release-helm-repo']
         );
         return;
     }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -21,6 +21,11 @@ module.exports = async (pluginConfig, context) => {
 };
 
 async function publishChart(configPath, registry, name, version, useS3 = false) {
+    await execa(
+        'helm',
+        ['dependency', 'update', configPath]
+    );
+
     if (useS3) {
         await execa(
             'helm',

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -19,6 +19,19 @@ module.exports = async (pluginConfig, context) => {
         }
     }
 
+    if (pluginConfig.registry && pluginConfig.registry.startsWith('s3://')) {
+        try {
+            await installS3HelmPlugin();
+        } catch (error) {
+            errors.push('Could not install helm-s3. Are you connected to the internet and is helm installed?', error);
+        }
+        try {
+            await verifyS3Credentials(pluginConfig.registry);
+        } catch (error) {
+            errors.push('Could not login to s3 registry. Wrong credentials?', error);
+        }
+    }
+
     if (errors.length > 0) {
         throw new AggregateError(errors);
     }
@@ -34,5 +47,19 @@ async function verifyRegistryLogin(registryUrl, registryUsername, registryPasswo
                 HELM_EXPERIMENTAL_OCI: 1
             }
         }
+    );
+}
+
+async function installS3HelmPlugin() {
+    await execa(
+        'helm',
+        ['plugin', 'install', 'https://github.com/hypnoglow/helm-s3.git']
+    );
+}
+
+async function verifyS3Credentials(registryUrl) {
+    await execa(
+        'helm',
+        ['repo', 'add', 'semantic-release-helm-repo', registryUrl]
     );
 }


### PR DESCRIPTION
Hey,

I am using helm-s3 for a private helm repo. Unfortunately, your plugin did not support the helm plugin. Therefore, I implemented support for it.

Also I added a new option called `onlyUpdateVersion`. It's useful for chart repos (like the old helm/charts) which are managed with semantic-release.