### PR TITLE
fix(verifyConditions): do not fail if helm-s3 is already installed

### DIFF
--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -23,7 +23,7 @@ module.exports = async (pluginConfig, context) => {
         try {
             await installS3HelmPlugin();
         } catch (error) {
-            errors.push('Could not install helm-s3. Are you connected to the internet and is helm installed?', error);
+            // Do not fail if the plugin is already installed.
         }
         try {
             await verifyS3Credentials(pluginConfig.registry);


### PR DESCRIPTION
Hey,

I ran into an issue if I use semantic release more than once during one pipeline run. (Use case: chart repo with monorepo approach).

Therefore I removed the `error.push` function for the `helm plugin install` command. If helm or the plugin is not installed, the `helm repo add` command will fail. This means, that an error is still triggered if the plugin or helm is not installed.