### PR TITLE
feat(publish): add --relative option for helm s3 push command

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -30,7 +30,7 @@ async function publishChart(configPath, registry, name, version) {
             );
             await execa(
                 'helm',
-                ['s3', 'push', path.join(configPath, chartName), 'semantic-release-helm']
+                ['s3', 'push', path.join(configPath, chartName), 'semantic-release-helm', '--relative']
             );
             await execa(
                 'rm',


### PR DESCRIPTION
Hey,

after some testing with s3-proxy, I found out that the `index.yaml` does not contain relative paths to the chart files. This is an issue because helm tries to use the s3:// url to pull the chart archive. But this is not the expected behaviour if you are using a proxy for your s3 bucket.

Therefore I added the relative option. This options fixes this problem.

Thanks in advance for reviewing this!