### PR TITLE
fix: changed lib in order to keep comments in yaml input

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -1,6 +1,6 @@
 const fsPromises = require('fs').promises;
 const path = require('path');
-const yaml = require('js-yaml');
+const yaml = require('yaml');
 const semver = require('semver');
 
 module.exports = async (pluginConfig, context) => {
@@ -11,7 +11,7 @@ module.exports = async (pluginConfig, context) => {
     const filePath = path.join(pluginConfig.chartPath, 'Chart.yaml');
 
     const chartYaml = await fsPromises.readFile(filePath);
-    const oldChart = yaml.load(chartYaml);
+    const oldChart = yaml.parseDocument(chartYaml).toString();
 
     let newChart;
     if (pluginConfig.onlyUpdateVersion) {


### PR DESCRIPTION
Link to issue: https://github.com/m1pl/semantic-release-helm/issues/26

### Description:
The previous `js-yaml` lib has been changed to `yaml` in prepare.js because this lib supports keeping comments in yaml input, which might be needed in order to retrieve some information. 

### Notes:
- In `prepare.js` in line 4 `const semver = require('semver');` is not used, can it be deleted?
- `publish.js` also uses the old lib. Should it be in alignment with `prepare.js` and use `yaml` instead of `js-yaml`?
- Please advise on how to include tests for this